### PR TITLE
Fix division by zero in average sales revenue calculation

### DIFF
--- a/Components/Pages/Configurations/EventUserPanel.razor
+++ b/Components/Pages/Configurations/EventUserPanel.razor
@@ -1222,7 +1222,11 @@
             totalSales = result.totalTicketSum;
             totalSalesTicketQuantity = result.totalTicketQuantity;
             totalAmountSettled = result.totalAmountSettled;
-            averageSalesRevenue = (result.totalTicketSum / result.totalTicketQuantity).ToString("C");
+            averageSalesRevenue =
+                (result.totalTicketQuantity > 0
+                    ? result.totalTicketSum / result.totalTicketQuantity
+                    : 0m
+                ).ToString("C");
 
             var sortDefinition = state.SortDefinitions.FirstOrDefault();
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -25,7 +25,7 @@
     "Vat" : 7.5,
     "StampDutyFee" : 50,
     "StampDutyAmount" : 10000,
-    "FlwPercentage": 1.40,
+    "FlwPercentage": 2.00,
     "FlwFeeCapAmount" : 2000
   }
 }


### PR DESCRIPTION
Added a check to prevent division by zero when calculating average sales revenue in EventUserPanel.razor. Also updated FlwPercentage from 1.40 to 2.00 in appsettings.json.