### PR TITLE
Fix null reference in payment transaction date display

### DIFF
--- a/Components/Pages/Configurations/UserDeatils.razor
+++ b/Components/Pages/Configurations/UserDeatils.razor
@@ -251,7 +251,12 @@
                                                     </TemplateColumn>
 
                                                     <TemplateColumn Title="TransDate" Sortable="false" Filterable="false">
-                                                        <CellTemplate Context="ctx"> @Convert.ToDateTime(ctx.Item.paymentDetails.paymentGateWayTransactionDate).ToString("dd MMM yyyy, HH:mm tt") </CellTemplate>
+                                                        <CellTemplate Context="ctx">
+                                                            @if (ctx.Item.paymentDetails != null)
+                                                            {
+                                                                @Convert.ToDateTime(ctx.Item.paymentDetails.paymentGateWayTransactionDate).ToString("dd MMM yyyy, HH:mm tt")
+                                                            }
+                                                        </CellTemplate>
                                                     </TemplateColumn>
 
                                                 </Columns>


### PR DESCRIPTION
Added a null check for paymentDetails before converting and displaying paymentGateWayTransactionDate to prevent potential runtime errors when paymentDetails is null.