### PR TITLE
Comment out ticket availability display

### DIFF
--- a/Components/Pages/Orders/BuyTickets.razor
+++ b/Components/Pages/Orders/BuyTickets.razor
@@ -69,7 +69,7 @@
 
 
                                                         <div style="">
-                                                            <div><small style="text-align: center"><b>Available : @tic.ticketInStock</b></small></div>
+                                                            @* <div><small style="text-align: center"><b>Available : @tic.ticketInStock</b></small></div> *@
 
                                                             <small> @tic.ticketDescription <br/>
                                                                 Admits @tic.groupSize person(s) each</small>


### PR DESCRIPTION
The line showing available tickets has been commented out in BuyTickets.razor. This may be to temporarily hide stock information from users or for future UI adjustments.