### PR TITLE
Order sales by createdAt and add createdAt to DTO

### DIFF
--- a/Components/Pages/Events/EventPanel.razor
+++ b/Components/Pages/Events/EventPanel.razor
@@ -1402,7 +1402,7 @@
                 }
             }
 
-            var pagedData = data.OrderByDescending(x => x.paymentDetails.paymentGateWayTransactionDate).ToArray();
+            var pagedData = data.OrderByDescending(x => x.createdAt).ToArray();
 
             _salesProcessing = false;
             StateHasChanged();

--- a/ivs.Domain/Models/Dtos/Payment/GetSalesDto.cs
+++ b/ivs.Domain/Models/Dtos/Payment/GetSalesDto.cs
@@ -28,6 +28,7 @@ namespace ivs.Domain.Models.Dtos.Payment
         public string? phoneNumber { get; set; }
         public int ticketQuantity { get; set; }
         public string? code { get; set; }
+        public DateTime? createdAt { get; set; }
         public bool isActive { get; set; }
         public decimal totalTicketFee { get; set; }
         public decimal ticketServiceFee { get; set; }


### PR DESCRIPTION
Changed sales ordering in EventPanel.razor to use createdAt instead of paymentGateWayTransactionDate. Added createdAt property to GetSalesDto to support this change.