### PR TITLE
Enable sorting by transaction date in EventPanel

### DIFF
--- a/Components/Pages/Events/EventPanel.razor
+++ b/Components/Pages/Events/EventPanel.razor
@@ -881,7 +881,7 @@
                                                 </CellTemplate>
                                             </TemplateColumn>
 
-                                            <TemplateColumn Title="TransDate" Sortable="false" Filterable="false">
+                                            <TemplateColumn Title="TransDate" Sortable="true" Filterable="false">
                                                 <CellTemplate Context="ctx">
                                                     @if (ctx.Item.paymentDetails != null)
                                                     {
@@ -1397,6 +1397,12 @@
                         data = data.OrderByDirection(
                             sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
                             o => o.phoneNumber
+                        );
+                        break;
+                    case nameof(GetSalesDataDto.paymentDetails.paymentGateWayTransactionDate):
+                        data = data.OrderByDirection(
+                            sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
+                            o => o.paymentDetails.paymentGateWayTransactionDate
                         );
                         break;
                 }


### PR DESCRIPTION
Made the 'TransDate' column sortable in the event panel and added backend support for sorting by payment gateway transaction date. This improves usability by allowing users to sort event sales data by transaction date.